### PR TITLE
Also replace already hashed filenames

### DIFF
--- a/tasks/wp-rev.js
+++ b/tasks/wp-rev.js
@@ -40,7 +40,7 @@ module.exports = function (grunt) {
                 regex = new RegExp('([0-9a-f]*\\.)*?' + filename),
                 content = grunt.file.read(options.file);
 
-                content = content.replace(regex, prefix + '.' + filename.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&'));
+                content = content.replace(regex, prefix + '.' + filename.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&'), 'g');
                 grunt.verbose.ok().ok(hash);
                 fs.renameSync(f, outPath);
                 grunt.log.write(f + ' ').ok(renamed);


### PR DESCRIPTION
In my project I needed to overwrite the asset references without exporting it to a build folder. The grunt task ended up prepending the hash to these filenames causing this effect: `'/css/79bc7f6e.79bc7f6e.79bc7f6e.theme.css'`

I've updated the regexp in the task to also find prepended hashes to replace, so any existing hashed filename will be updated to the new version when saving.
